### PR TITLE
Fix getBasePath() on Windows

### DIFF
--- a/src/Scrutinizer/Ocular/Command/CodeCoverage/UploadCommand.php
+++ b/src/Scrutinizer/Ocular/Command/CodeCoverage/UploadCommand.php
@@ -102,7 +102,7 @@ class UploadCommand extends Command
     {
         $dir = getcwd();
         while ( ! empty($dir)) {
-            if (is_dir($dir.'/.git')) {
+            if (is_dir($dir.DIRECTORY_SEPARATOR.'.git')) {
                 return $dir;
             }
 


### PR DESCRIPTION
getBasePath() could not determine .git directory because Windows uses \.